### PR TITLE
Add heartbeat & OnOff timeout

### DIFF
--- a/broadcaster/broadcaster.js
+++ b/broadcaster/broadcaster.js
@@ -62,11 +62,16 @@ class OSCBroadcaster {
   }
 
   publishHeadset(state) {
-    // Send an eeg OSC message
+    this.publishEEG(state);
+    this.publishOnOff(state);
+  }
+
+  publishEEG(state) {
     const eegData = state.toOscEeg()
     this.publishToAll("/eeg", eegData);
+  }
 
-    // Send an on/off OSC message
+  publishOnOff(state) {
     const onOffData = state.toOscOnOff()
     this.publishToAll("/onoff", onOffData);
   }

--- a/broadcaster/main.js
+++ b/broadcaster/main.js
@@ -76,9 +76,9 @@ firebaseBroadcaster.subscribe(onRemoteData);
 
 // setup the server so that everything it receives some new data it is
 // published to the remote data server.
-const onOffThreashold = .5
-const onOffWindowSize = 3
 const model = new appState.OnOffModel(onOffThreashold, onOffWindowSize);
+const onOffThreashold = .5;
+const onOffWindowSize = 3;
 const state = new appState.State(model);
 const onLocalData = (body) => {
   state.addData(body)

--- a/broadcaster/main.js
+++ b/broadcaster/main.js
@@ -76,9 +76,14 @@ firebaseBroadcaster.subscribe(onRemoteData);
 
 // setup the server so that everything it receives some new data it is
 // published to the remote data server.
-const model = new appState.OnOffModel(onOffThreashold, onOffWindowSize);
 const onOffThreashold = .5;
 const onOffWindowSize = 3;
+const onOffExpirationSeconds = 30;
+const model = new appState.OnOffModel({
+  threashold: onOffThreashold,
+  windowSize: onOffWindowSize,
+  expiration: onOffExpirationSeconds*1000,
+});
 const state = new appState.State(model);
 const onLocalData = (body) => {
   state.addData(body)

--- a/broadcaster/main.js
+++ b/broadcaster/main.js
@@ -92,3 +92,12 @@ const onLocalData = (body) => {
 }
 const webServer = new server.Server(argv.port, onLocalData);
 webServer.start();
+
+// Periodically, send the state's heartbeat
+const heartbeatSeconds = 5;
+const heartbeat = () => {
+  console.log("Heartbeat");
+  firebaseBroadcaster.publish(state);
+  oscBroadcaster.publishOnOff(state);
+};
+setInterval(heartbeat, heartbeatSeconds*1000);

--- a/broadcaster/main.js
+++ b/broadcaster/main.js
@@ -65,7 +65,12 @@ const signalBank = new similarity.SignalBank(argv.eegHeadsetId, bankWindowSize);
 const onRemoteData = (snapshot) => {
   signalBank.addSamples(snapshot.val());
   const sim = signalBank.similarity();
-  oscBroadcaster.publishSimilarity(sim + 0.0000001);
+
+  // Note that the small delta values is a hack to get around a "feature" of
+  // the osc library that sends integers.  After digging through the library,
+  // we found that it reports integers if the floor of the value is the value.
+  const hackedSim = Math.floor(sim) === sim ? sim + .0000001 : sim;
+  oscBroadcaster.publishSimilarity(hackedSim);
 };
 firebaseBroadcaster.subscribe(onRemoteData);
 

--- a/broadcaster/similarity.js
+++ b/broadcaster/similarity.js
@@ -97,7 +97,8 @@ class Signal {
 
   addSample(time, value, headsetOn) {
     if (this.lastSample() && time < this.lastSample().time) {
-      throw "Time must move forward";
+      console.warn("Time must move forward");
+      return;
     }
 
     const sample = new Sample(time, value);

--- a/broadcaster/state.js
+++ b/broadcaster/state.js
@@ -64,7 +64,7 @@ class State {
 
   toOscEeg() {
     return [
-      this.timestamp,
+      Math.floor(this.timestamp/1000),
       this.delta,
       this.hiAlpha,
       this.hiBeta,

--- a/broadcaster/state.js
+++ b/broadcaster/state.js
@@ -55,10 +55,10 @@ class State {
     this.midGamma = data.midGamma;
     this.signal = data.signal;
     this.theta = data.theta;
-    this.timestamp = data.timestamp;
+    this.timestamp = data.timestamp*1000;
     this.onOffModel.addSample({
       sample: data.signal,
-      timestamp: data.timestamp,
+      timestamp: this.timestamp,
     });
   }
 

--- a/broadcaster/test/similarity_test.js
+++ b/broadcaster/test/similarity_test.js
@@ -201,8 +201,9 @@ suite('similarity', function () {
   suite('SignalBank', function() {
     const makeRawData = (val, headsetOn, timeDelta=0) => {
       return {
+        headsetOn,
         raw_data: {
-          delta: val, headsetOn, timestamp: Date.now()+timeDelta,
+          delta: val, timestamp: Date.now()+timeDelta,
         },
       };
     };

--- a/broadcaster/test/similarity_test.js
+++ b/broadcaster/test/similarity_test.js
@@ -259,17 +259,19 @@ suite('similarity', function () {
     });
 
     suite('#getActiveRemoteSignals', function() {
-      const bank = new similarity.SignalBank('local', 1);
+      test('it gets the active signals', function() {
+        const bank = new similarity.SignalBank('local', 1);
 
-      bank.addSamples({
-        local: makeRawData(10, true),
-        remote: makeRawData(11, true),
+        bank.addSamples({
+          local: makeRawData(10, true),
+          remote: makeRawData(11, true),
+        });
+        const remoteSignal = bank.getSignal('remote');
+        bank.getSignal('remoteInactive');
+
+        assert.deepEqual([remoteSignal], bank.getActiveRemoteSignals());
       });
-      const remoteSignal = bank.getSignal('remote');
-      bank.getSignal('remoteInactive');
-
-      assert.deepEqual([remoteSignal], bank.getActiveRemoteSignals());
-    })
+    });
 
     suite('#similarity', function() {
       test('it returns 0 when local is inactive', function() {

--- a/broadcaster/test/state_test.js
+++ b/broadcaster/test/state_test.js
@@ -6,39 +6,76 @@ const state = require('../state');
 
 suite('state', function() {
   suite('OnOffModel', function() {
+    const makeModel = () => new state.OnOffModel({
+      threashold: .5,
+      windowSize: 3,
+      expiration: 30*1000,
+    });
+
     suite('constructor', function() {
       test('it initializes', function() {
-        const m = new state.OnOffModel(.5, 3);
-        assert.equal(.5, m.threashold);
+        const m = new state.OnOffModel({
+          threashold: .75,
+          windowSize: 3,
+          expiration: 10,
+        });
+        assert.equal(.75, m.threashold);
         assert.deepEqual([255, 255, 255], m.samples);
+        assert.equal(10, m.expiration);
       });
     });
 
     suite('addSample', function() {
       test('buffer is filled from back', function() {
-        const m = new state.OnOffModel(.5, 3);
-        m.addSample(8);
+        const m = makeModel();
+        m.addSample({sample: 8, timestamp: 35});
         assert.deepEqual([255, 255, 8], m.samples);
+      });
+
+      test('it keeps most recent timestamp', function() {
+        const m = makeModel();
+        m.addSample({sample: 9, timestamp: 40});
+        m.addSample({sample: 8, timestamp: 35});
+        assert.equal(40, m.lastUpdate);
+
       });
     });
 
 
     suite('isOn', function() {
-      test('it is on for low values', function() {
-        const m = new state.OnOffModel(.5, 2);
-        m.samples = [4, 10];
+      const makeModel = () => new state.OnOffModel({
+        threashold: .5,
+        windowSize: 2,
+        expiration: 30*1000,
+      });
+
+      test('it is on for low values with recent update', function() {
+        const m = makeModel();
+        m.addSample({sample: 4, timestamp: Date.now - 2000});
+        m.addSample({sample: 9, timestamp: Date.now - 1025});
+        m.lastUpdate = Date.now();
         assert.equal(true, m.isOn());
       });
 
-      test('it is off for high values', function() {
-        const m = new state.OnOffModel(.5, 2);
-        m.samples = [225, 250];
+      test('it is off for low values with non-recent update', function() {
+        const m = makeModel();
+        m.addSample({sample: 4, timestamp: Date.now - 70*1000});
+        m.addSample({sample: 9, timestamp: Date.now - 60*1000});
+        assert.equal(false, m.isOn());
+      });
+
+      test('it is off for recently updated high values', function() {
+        const m = makeModel();
+        m.addSample({sample: 225, timestamp: Date.now - 2000});
+        m.addSample({sample: 250, timestamp: Date.now - 1025});
+        m.lastUpdate = Date.now();
         assert.equal(false, m.isOn());
       });
     });
   });
 
   suite('State', function() {
+    const now = Date.now();
     const data = {
       attention: 1,
       delta: 2,
@@ -51,11 +88,15 @@ suite('state', function() {
       midGamma: 9,
       signal: 10,
       theta: 11,
-      timestamp: 12
+      timestamp: now,
     };
 
     const makeState = () => {
-      const m = new state.OnOffModel(.5, 1);
+      const m = new state.OnOffModel({
+        threashold: .5,
+        windowSize: 1,
+        expiration: 10*1000,
+      });
       return new state.State(m);
     };
 
@@ -81,14 +122,14 @@ suite('state', function() {
         assert.equal(9, s.midGamma);
         assert.equal(10, s.signal);
         assert.equal(11, s.theta);
-        assert.equal(12, s.timestamp);
+        assert.equal(now, s.timestamp);
         assert.deepEqual([10], s.onOffModel.samples);
       });
     });
 
     suite('#toOscEeg', function() {
       const s = makeAndFillState();
-      assert.deepEqual([12, 2, 3, 4, 5, 6, 7, 9, 11], s.toOscEeg());
+      assert.deepEqual([now, 2, 3, 4, 5, 6, 7, 9, 11], s.toOscEeg());
     });
 
     suite('#toOscOnOff', function() {

--- a/broadcaster/test/state_test.js
+++ b/broadcaster/test/state_test.js
@@ -128,13 +128,17 @@ suite('state', function() {
     });
 
     suite('#toOscEeg', function() {
-      const s = makeAndFillState();
-      assert.deepEqual([now, 2, 3, 4, 5, 6, 7, 9, 11], s.toOscEeg());
+      test('it creates correct osc messages', function() {
+        const s = makeAndFillState();
+        assert.deepEqual([nowSeconds, 2, 3, 4, 5, 6, 7, 9, 11], s.toOscEeg());
+      });
     });
 
     suite('#toOscOnOff', function() {
-      const s = makeAndFillState();
-      assert.deepEqual([1], s.toOscOnOff());
+      test('it makes correct osc message', function() {
+        const s = makeAndFillState();
+        assert.deepEqual([1], s.toOscOnOff());
+      });
     });
   });
 });

--- a/broadcaster/test/state_test.js
+++ b/broadcaster/test/state_test.js
@@ -82,7 +82,7 @@ suite('state', function() {
         assert.equal(10, s.signal);
         assert.equal(11, s.theta);
         assert.equal(12, s.timestamp);
-        assert.deepEqual([2], s.onOffModel.samples);
+        assert.deepEqual([10], s.onOffModel.samples);
       });
     });
 

--- a/broadcaster/test/state_test.js
+++ b/broadcaster/test/state_test.js
@@ -75,7 +75,7 @@ suite('state', function() {
   });
 
   suite('State', function() {
-    const now = Date.now();
+    const nowSeconds = Math.floor(Date.now()/1000);
     const data = {
       attention: 1,
       delta: 2,
@@ -88,7 +88,7 @@ suite('state', function() {
       midGamma: 9,
       signal: 10,
       theta: 11,
-      timestamp: now,
+      timestamp: nowSeconds,
     };
 
     const makeState = () => {
@@ -122,7 +122,7 @@ suite('state', function() {
         assert.equal(9, s.midGamma);
         assert.equal(10, s.signal);
         assert.equal(11, s.theta);
-        assert.equal(now, s.timestamp);
+        assert.equal(nowSeconds*1000, s.timestamp);
         assert.deepEqual([10], s.onOffModel.samples);
       });
     });


### PR DESCRIPTION
**Summary**
Add an expiration to the on off model.  That is
after some period of time, if the on off model has
not received any new data it is assumed that the headset
is now off.  This allows us to fall back to the OFF state
if the headset fails.

Since there can now have state changes to without a headset
event, we periodically update the "derived" state on a
heartbeat from the broadcaster.